### PR TITLE
fix: Fixed top navigation bar in homepage.css so content is not blocked

### DIFF
--- a/src/nestdoorapp/static/css/homepage.css
+++ b/src/nestdoorapp/static/css/homepage.css
@@ -26,7 +26,7 @@
 
 body {
     background-color: floralwhite;
-    padding-top: 20px;
+    padding-top: 50px;
   }
   h1 {
     color: black;

--- a/src/nestdoorapp/templates/homepage.html
+++ b/src/nestdoorapp/templates/homepage.html
@@ -4,7 +4,6 @@
     <head>
         <link rel="stylesheet" type="text/css" href="{% static '/css/homepage.css' %}" />
         <meta charset="UTF-8" />
-        name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Home Page</title>
     </head>
     <body>


### PR DESCRIPTION
The top navigation bar was blocking content underneath it. This seems to have stemmed from the `padding-top` variable for `body` in `homepage.css` being too low of a value.

* Changed `padding-top` variable for `body` in `homepage.css` to `50px`. This seems to have given enough room for the top navigation bar to not block anything.
* Removed `name="viewport" content="width=device-width, initial-scale=1.0" />` from `head` in `homepage.html` because it served no purpose and was randomly inserted at the top of the page.

resolves: #45