### PR TITLE
feat: The "Back to Forum" text is now clickable

### DIFF
--- a/src/nestdoorapp/templates/userpost.html
+++ b/src/nestdoorapp/templates/userpost.html
@@ -72,7 +72,7 @@
                               <path d="M13.723 2.286l-13.723 13.714 13.719 13.714"></path>
                             </svg>
                           </a>
-                          <h3>Back to Forum</h3>
+                          <a href="{% url 'forum' %}">Back to Forum</a>
                         </div>
                         {% if post.posted_by == user %}
                         <div class="post__topRight">


### PR DESCRIPTION
The user can now click the "Back to Forum" text
and it will redirect them to the fourms
Change the <h3> tag to a <a href> tag in userpost.html line 75

Issue: "Back to Forum" link on Detailed Post page#79


<img width="1352" alt="Screenshot 2023-11-24 at 8 55 43 PM" src="https://github.com/COSC481W-2023Fall/nestdoor-app/assets/91636359/6fb11c27-c8fa-4b5f-ba9c-e261570d67af">