### PR TITLE
Style & Fix: Placeholder Text in About Me on Profile Page

### DIFF
--- a/src/nestdoorapp/views.py
+++ b/src/nestdoorapp/views.py
@@ -258,9 +258,9 @@ def user_profile_view(request, user_id):
             user_ext.about_me = request.POST["about_me"]
             user_ext.save()
             context["about_me"] = user_ext.about_me
-        else:
-            # default about me
-            context["about_me"] = "This user has not filled out this about me yet."
+        #else:
+            #default about me
+            #context["about_me"] = "This user has not filled out this about me yet."
 
     # build context variables
     context["username"] = user.username.upper()


### PR DESCRIPTION
The About Me on Profile Page now has a placeholder

- added code to userprofilepage.html for placeholder to say "Tell us about yourself" in a light grey text that can be seen when a user is logged in

- edited the title for the userprofilepage.html to say "{User}'s Profile Page"

- commented out else block in views.py with default about me content because it was overriding the placeholder 